### PR TITLE
Add option to unquote animation names

### DIFF
--- a/src/sass/make-transitions.scss
+++ b/src/sass/make-transitions.scss
@@ -1,3 +1,11 @@
+@function quoteIf($property, $condition) {
+  @if ($condition == true) {
+    @return '#{$property}';
+  } @else {
+    @return $property;
+  }
+}
+
 @mixin make-transitions($base, $names) {
 
   // We'll make a single rule for all transitions that
@@ -19,11 +27,11 @@
 
   // Entrance/Exit for the base class
   .#{$base}-enter-active, .#{$base}In {
-    animation-name: '#{$base}In';
+    animation-name: quoteIf(#{$base}In, $quoteAnimationNames);
   }
 
   .#{$base}-leave-active, .#{$base}Out {
-    animation-name: '#{$base}Out';
+    animation-name: quoteIf(#{$base}Out, $quoteAnimationNames);
   }
 
   // Loop through the different animations, and set
@@ -36,10 +44,10 @@
     }
 
     .#{$base}#{$name}-enter-active, .#{$base}In#{$name} {
-      animation-name: '#{$base}In#{$name}';
+      animation-name: quoteIf(#{$base}In#{$name}, $quoteAnimationNames);
     }
     .#{$base}#{$name}-leave-active, .#{$base}Out#{$name} {
-      animation-name: '#{$base}Out#{$name}';
+      animation-name: quoteIf(#{$base}Out#{$name}, $quoteAnimationNames);
     }
   }
 }

--- a/src/sass/vue2-animate.scss
+++ b/src/sass/vue2-animate.scss
@@ -8,6 +8,7 @@
  */
 
 $animationDuration: 1s !default;
+$quoteAnimationNames: true !default;
 
 // Main mixin
 @import "make-transitions";


### PR DESCRIPTION
Helps fixing a bug where browser won't parse quoted animation names.
By default animation names should not contain quotes.

https://developer.mozilla.org/es/docs/Web/CSS/animation-name

Example of code generated by this library:

```
.fadeLeft-enter-active, .fadeInLeft {
    animation-name: "fadeInLeft";
}
```
This will be marked as invalid in`Chrome Version 67.0.3396.99 (Official Build) (64-bit)` 

This PR adds the `quoteAnimationNames` variable, which will generate unquoted animation names when set as `false`. It is set as `true` for backwards compatibility.

Usage:

```
$animationDuration: 600ms;
$quoteAnimationNames: false;
@import 'vue2-animate/src/sass/vue2-animate';
```

Related Issues

[Chromium Forums](https://bugs.chromium.org/p/chromium/issues/detail?id=423424)
